### PR TITLE
chore: Migrate datacatalog synth.py to bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@ Java idiomatic client for [Data Catalog][product-docs].
 
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 ```xml
-<dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>4.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>libraries-bom</artifactId>
-      <version>4.2.0</version>
-      <type>pom</type>
-      <scope>import</scope>
+      <artifactId>google-cloud-datacatalog</artifactId>
     </dependency>
-  </dependencies>
-</dependencyManagement>
-
-<dependencies>
-  <dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-datacatalog</artifactId>
-  </dependency>
 
 ```
 
@@ -40,11 +40,11 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 If you are using Maven without BOM, add this to your dependencies:
 
 ```xml
-<dependency>
-  <groupId>com.google.cloud</groupId>
-  <artifactId>google-cloud-datacatalog</artifactId>
-  <version>0.33.0</version>
-</dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datacatalog</artifactId>
+      <version>0.33.0</version>
+    </dependency>
 
 ```
 

--- a/grpc-google-cloud-datacatalog-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-datacatalog-v1beta1/clirr-ignored-differences.xml
@@ -5,4 +5,8 @@
     <differenceType>8001</differenceType>
     <className>com/google/cloud/datacatalog/*</className>
   </difference>
+  <!-- TODO: remove after 0.33.1 released -->
+  <differenceType>6001</differenceType>
+  <className>com/google/cloud/datacatalog/v1beta1/*Grpc</className>
+  <field>METHOD_*</field>
 </differences>

--- a/grpc-google-cloud-datacatalog-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-datacatalog-v1beta1/clirr-ignored-differences.xml
@@ -6,7 +6,9 @@
     <className>com/google/cloud/datacatalog/*</className>
   </difference>
   <!-- TODO: remove after 0.33.1 released -->
-  <differenceType>6001</differenceType>
-  <className>com/google/cloud/datacatalog/v1beta1/*Grpc</className>
-  <field>METHOD_*</field>
+  <difference>
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/datacatalog/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
 </differences>

--- a/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/DataCatalogGrpc.java
+++ b/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/DataCatalogGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/datacatalog/v1beta1/datacatalog.proto")
 public final class DataCatalogGrpc {
 
@@ -40,30 +40,20 @@ public final class DataCatalogGrpc {
   public static final String SERVICE_NAME = "google.cloud.datacatalog.v1beta1.DataCatalog";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSearchCatalogMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
-          com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
-      METHOD_SEARCH_CATALOG = getSearchCatalogMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
           com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
       getSearchCatalogMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SearchCatalog",
+      requestType = com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
           com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
       getSearchCatalogMethod() {
-    return getSearchCatalogMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
-          com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
-      getSearchCatalogMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
             com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
@@ -78,9 +68,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "SearchCatalog"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SearchCatalog"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -98,30 +86,20 @@ public final class DataCatalogGrpc {
     return getSearchCatalogMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateEntryGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      METHOD_CREATE_ENTRY_GROUP = getCreateEntryGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getCreateEntryGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateEntryGroup",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.EntryGroup.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getCreateEntryGroupMethod() {
-    return getCreateEntryGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      getCreateEntryGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
@@ -136,9 +114,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.EntryGroup>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "CreateEntryGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateEntryGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -156,30 +132,20 @@ public final class DataCatalogGrpc {
     return getCreateEntryGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateEntryGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      METHOD_UPDATE_ENTRY_GROUP = getUpdateEntryGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getUpdateEntryGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateEntryGroup",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.EntryGroup.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getUpdateEntryGroupMethod() {
-    return getUpdateEntryGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      getUpdateEntryGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
@@ -194,9 +160,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.EntryGroup>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "UpdateEntryGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateEntryGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -214,30 +178,20 @@ public final class DataCatalogGrpc {
     return getUpdateEntryGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetEntryGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      METHOD_GET_ENTRY_GROUP = getGetEntryGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getGetEntryGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetEntryGroup",
+      requestType = com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.EntryGroup.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
           com.google.cloud.datacatalog.v1beta1.EntryGroup>
       getGetEntryGroupMethod() {
-    return getGetEntryGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
-          com.google.cloud.datacatalog.v1beta1.EntryGroup>
-      getGetEntryGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
@@ -252,9 +206,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.EntryGroup>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "GetEntryGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetEntryGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -271,26 +223,18 @@ public final class DataCatalogGrpc {
     return getGetEntryGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteEntryGroupMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ENTRY_GROUP = getDeleteEntryGroupMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest, com.google.protobuf.Empty>
       getDeleteEntryGroupMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteEntryGroup",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest, com.google.protobuf.Empty>
       getDeleteEntryGroupMethod() {
-    return getDeleteEntryGroupMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest, com.google.protobuf.Empty>
-      getDeleteEntryGroupMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest, com.google.protobuf.Empty>
         getDeleteEntryGroupMethod;
@@ -304,9 +248,7 @@ public final class DataCatalogGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "DeleteEntryGroup"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteEntryGroup"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -324,30 +266,20 @@ public final class DataCatalogGrpc {
     return getDeleteEntryGroupMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListEntryGroupsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
-      METHOD_LIST_ENTRY_GROUPS = getListEntryGroupsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
           com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
       getListEntryGroupsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListEntryGroups",
+      requestType = com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
           com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
       getListEntryGroupsMethod() {
-    return getListEntryGroupsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
-      getListEntryGroupsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
             com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
@@ -362,9 +294,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "ListEntryGroups"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListEntryGroups"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -383,30 +313,20 @@ public final class DataCatalogGrpc {
     return getListEntryGroupsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateEntryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      METHOD_CREATE_ENTRY = getCreateEntryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getCreateEntryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateEntry",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateEntryRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Entry.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getCreateEntryMethod() {
-    return getCreateEntryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      getCreateEntryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
             com.google.cloud.datacatalog.v1beta1.Entry>
@@ -421,9 +341,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Entry>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "CreateEntry"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateEntry"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -440,30 +358,20 @@ public final class DataCatalogGrpc {
     return getCreateEntryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateEntryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      METHOD_UPDATE_ENTRY = getUpdateEntryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getUpdateEntryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateEntry",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Entry.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getUpdateEntryMethod() {
-    return getUpdateEntryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      getUpdateEntryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
             com.google.cloud.datacatalog.v1beta1.Entry>
@@ -478,9 +386,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Entry>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "UpdateEntry"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateEntry"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -497,26 +403,18 @@ public final class DataCatalogGrpc {
     return getUpdateEntryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteEntryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ENTRY = getDeleteEntryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest, com.google.protobuf.Empty>
       getDeleteEntryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteEntry",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest, com.google.protobuf.Empty>
       getDeleteEntryMethod() {
-    return getDeleteEntryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest, com.google.protobuf.Empty>
-      getDeleteEntryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest, com.google.protobuf.Empty>
         getDeleteEntryMethod;
@@ -530,9 +428,7 @@ public final class DataCatalogGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "DeleteEntry"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteEntry"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -549,30 +445,20 @@ public final class DataCatalogGrpc {
     return getDeleteEntryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetEntryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      METHOD_GET_ENTRY = getGetEntryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getGetEntryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetEntry",
+      requestType = com.google.cloud.datacatalog.v1beta1.GetEntryRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Entry.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getGetEntryMethod() {
-    return getGetEntryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      getGetEntryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
             com.google.cloud.datacatalog.v1beta1.Entry>
@@ -587,9 +473,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Entry>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "GetEntry"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetEntry"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -606,30 +490,20 @@ public final class DataCatalogGrpc {
     return getGetEntryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getLookupEntryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      METHOD_LOOKUP_ENTRY = getLookupEntryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getLookupEntryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "LookupEntry",
+      requestType = com.google.cloud.datacatalog.v1beta1.LookupEntryRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Entry.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
           com.google.cloud.datacatalog.v1beta1.Entry>
       getLookupEntryMethod() {
-    return getLookupEntryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
-          com.google.cloud.datacatalog.v1beta1.Entry>
-      getLookupEntryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
             com.google.cloud.datacatalog.v1beta1.Entry>
@@ -644,9 +518,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Entry>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "LookupEntry"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "LookupEntry"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -663,30 +535,20 @@ public final class DataCatalogGrpc {
     return getLookupEntryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListEntriesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
-          com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
-      METHOD_LIST_ENTRIES = getListEntriesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
           com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
       getListEntriesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListEntries",
+      requestType = com.google.cloud.datacatalog.v1beta1.ListEntriesRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ListEntriesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
           com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
       getListEntriesMethod() {
-    return getListEntriesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
-          com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
-      getListEntriesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
             com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
@@ -701,9 +563,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "ListEntries"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListEntries"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -721,30 +581,20 @@ public final class DataCatalogGrpc {
     return getListEntriesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateTagTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      METHOD_CREATE_TAG_TEMPLATE = getCreateTagTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getCreateTagTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateTagTemplate",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getCreateTagTemplateMethod() {
-    return getCreateTagTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      getCreateTagTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
@@ -759,9 +609,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.TagTemplate>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "CreateTagTemplate"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTagTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -780,30 +628,20 @@ public final class DataCatalogGrpc {
     return getCreateTagTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetTagTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      METHOD_GET_TAG_TEMPLATE = getGetTagTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getGetTagTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetTagTemplate",
+      requestType = com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getGetTagTemplateMethod() {
-    return getGetTagTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      getGetTagTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
@@ -818,9 +656,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.TagTemplate>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "GetTagTemplate"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTagTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -839,30 +675,20 @@ public final class DataCatalogGrpc {
     return getGetTagTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateTagTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      METHOD_UPDATE_TAG_TEMPLATE = getUpdateTagTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getUpdateTagTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateTagTemplate",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplate>
       getUpdateTagTemplateMethod() {
-    return getUpdateTagTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplate>
-      getUpdateTagTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
@@ -877,9 +703,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.TagTemplate>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "UpdateTagTemplate"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTagTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -898,26 +722,18 @@ public final class DataCatalogGrpc {
     return getUpdateTagTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteTagTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_TAG_TEMPLATE = getDeleteTagTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest, com.google.protobuf.Empty>
       getDeleteTagTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteTagTemplate",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest, com.google.protobuf.Empty>
       getDeleteTagTemplateMethod() {
-    return getDeleteTagTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest, com.google.protobuf.Empty>
-      getDeleteTagTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest,
             com.google.protobuf.Empty>
@@ -932,9 +748,7 @@ public final class DataCatalogGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "DeleteTagTemplate"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteTagTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -952,30 +766,20 @@ public final class DataCatalogGrpc {
     return getDeleteTagTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateTagTemplateFieldMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      METHOD_CREATE_TAG_TEMPLATE_FIELD = getCreateTagTemplateFieldMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getCreateTagTemplateFieldMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateTagTemplateField",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplateField.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getCreateTagTemplateFieldMethod() {
-    return getCreateTagTemplateFieldMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      getCreateTagTemplateFieldMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplateField>
@@ -993,9 +797,7 @@ public final class DataCatalogGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog",
-                              "CreateTagTemplateField"))
+                          generateFullMethodName(SERVICE_NAME, "CreateTagTemplateField"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1014,30 +816,20 @@ public final class DataCatalogGrpc {
     return getCreateTagTemplateFieldMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateTagTemplateFieldMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      METHOD_UPDATE_TAG_TEMPLATE_FIELD = getUpdateTagTemplateFieldMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getUpdateTagTemplateFieldMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateTagTemplateField",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplateField.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getUpdateTagTemplateFieldMethod() {
-    return getUpdateTagTemplateFieldMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      getUpdateTagTemplateFieldMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplateField>
@@ -1055,9 +847,7 @@ public final class DataCatalogGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog",
-                              "UpdateTagTemplateField"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateTagTemplateField"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1076,30 +866,20 @@ public final class DataCatalogGrpc {
     return getUpdateTagTemplateFieldMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRenameTagTemplateFieldMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      METHOD_RENAME_TAG_TEMPLATE_FIELD = getRenameTagTemplateFieldMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getRenameTagTemplateFieldMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RenameTagTemplateField",
+      requestType = com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.TagTemplateField.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
           com.google.cloud.datacatalog.v1beta1.TagTemplateField>
       getRenameTagTemplateFieldMethod() {
-    return getRenameTagTemplateFieldMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
-          com.google.cloud.datacatalog.v1beta1.TagTemplateField>
-      getRenameTagTemplateFieldMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
             com.google.cloud.datacatalog.v1beta1.TagTemplateField>
@@ -1117,9 +897,7 @@ public final class DataCatalogGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog",
-                              "RenameTagTemplateField"))
+                          generateFullMethodName(SERVICE_NAME, "RenameTagTemplateField"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1138,30 +916,20 @@ public final class DataCatalogGrpc {
     return getRenameTagTemplateFieldMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteTagTemplateFieldMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_TAG_TEMPLATE_FIELD = getDeleteTagTemplateFieldMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
           com.google.protobuf.Empty>
       getDeleteTagTemplateFieldMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteTagTemplateField",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
           com.google.protobuf.Empty>
       getDeleteTagTemplateFieldMethod() {
-    return getDeleteTagTemplateFieldMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
-          com.google.protobuf.Empty>
-      getDeleteTagTemplateFieldMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
             com.google.protobuf.Empty>
@@ -1179,9 +947,7 @@ public final class DataCatalogGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog",
-                              "DeleteTagTemplateField"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteTagTemplateField"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1199,30 +965,20 @@ public final class DataCatalogGrpc {
     return getDeleteTagTemplateFieldMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
-          com.google.cloud.datacatalog.v1beta1.Tag>
-      METHOD_CREATE_TAG = getCreateTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
           com.google.cloud.datacatalog.v1beta1.Tag>
       getCreateTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateTagRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Tag.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
           com.google.cloud.datacatalog.v1beta1.Tag>
       getCreateTagMethod() {
-    return getCreateTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
-          com.google.cloud.datacatalog.v1beta1.Tag>
-      getCreateTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
             com.google.cloud.datacatalog.v1beta1.Tag>
@@ -1237,9 +993,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Tag>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "CreateTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1256,30 +1010,20 @@ public final class DataCatalogGrpc {
     return getCreateTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
-          com.google.cloud.datacatalog.v1beta1.Tag>
-      METHOD_UPDATE_TAG = getUpdateTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
           com.google.cloud.datacatalog.v1beta1.Tag>
       getUpdateTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateTagRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Tag.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
           com.google.cloud.datacatalog.v1beta1.Tag>
       getUpdateTagMethod() {
-    return getUpdateTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
-          com.google.cloud.datacatalog.v1beta1.Tag>
-      getUpdateTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
             com.google.cloud.datacatalog.v1beta1.Tag>
@@ -1294,9 +1038,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.Tag>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "UpdateTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1313,26 +1055,18 @@ public final class DataCatalogGrpc {
     return getUpdateTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_TAG = getDeleteTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagRequest, com.google.protobuf.Empty>
       getDeleteTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteTagRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTagRequest, com.google.protobuf.Empty>
       getDeleteTagMethod() {
-    return getDeleteTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTagRequest, com.google.protobuf.Empty>
-      getDeleteTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteTagRequest, com.google.protobuf.Empty>
         getDeleteTagMethod;
@@ -1346,9 +1080,7 @@ public final class DataCatalogGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "DeleteTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1365,30 +1097,20 @@ public final class DataCatalogGrpc {
     return getDeleteTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListTagsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
-      METHOD_LIST_TAGS = getListTagsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
           com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
       getListTagsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListTags",
+      requestType = com.google.cloud.datacatalog.v1beta1.ListTagsRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ListTagsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
           com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
       getListTagsMethod() {
-    return getListTagsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
-      getListTagsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
             com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
@@ -1403,9 +1125,7 @@ public final class DataCatalogGrpc {
                           com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "ListTags"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTags"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1423,26 +1143,18 @@ public final class DataCatalogGrpc {
     return getListTagsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = DataCatalogGrpc.getSetIamPolicyMethod) == null) {
@@ -1453,9 +1165,7 @@ public final class DataCatalogGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1471,26 +1181,18 @@ public final class DataCatalogGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = DataCatalogGrpc.getGetIamPolicyMethod) == null) {
@@ -1501,9 +1203,7 @@ public final class DataCatalogGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1519,26 +1219,18 @@ public final class DataCatalogGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -1553,9 +1245,7 @@ public final class DataCatalogGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.DataCatalog", "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1574,19 +1264,42 @@ public final class DataCatalogGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static DataCatalogStub newStub(io.grpc.Channel channel) {
-    return new DataCatalogStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DataCatalogStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DataCatalogStub>() {
+          @java.lang.Override
+          public DataCatalogStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DataCatalogStub(channel, callOptions);
+          }
+        };
+    return DataCatalogStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static DataCatalogBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new DataCatalogBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DataCatalogBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DataCatalogBlockingStub>() {
+          @java.lang.Override
+          public DataCatalogBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DataCatalogBlockingStub(channel, callOptions);
+          }
+        };
+    return DataCatalogBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static DataCatalogFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new DataCatalogFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DataCatalogFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DataCatalogFutureStub>() {
+          @java.lang.Override
+          public DataCatalogFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DataCatalogFutureStub(channel, callOptions);
+          }
+        };
+    return DataCatalogFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1621,7 +1334,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSearchCatalogMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSearchCatalogMethod(), responseObserver);
     }
 
     /**
@@ -1648,7 +1361,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateEntryGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateEntryGroupMethod(), responseObserver);
     }
 
     /**
@@ -1665,7 +1378,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateEntryGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateEntryGroupMethod(), responseObserver);
     }
 
     /**
@@ -1679,7 +1392,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetEntryGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetEntryGroupMethod(), responseObserver);
     }
 
     /**
@@ -1695,7 +1408,7 @@ public final class DataCatalogGrpc {
     public void deleteEntryGroup(
         com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteEntryGroupMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteEntryGroupMethod(), responseObserver);
     }
 
     /**
@@ -1709,7 +1422,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListEntryGroupsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListEntryGroupsMethod(), responseObserver);
     }
 
     /**
@@ -1727,7 +1440,7 @@ public final class DataCatalogGrpc {
     public void createEntry(
         com.google.cloud.datacatalog.v1beta1.CreateEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateEntryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateEntryMethod(), responseObserver);
     }
 
     /**
@@ -1743,7 +1456,7 @@ public final class DataCatalogGrpc {
     public void updateEntry(
         com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateEntryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateEntryMethod(), responseObserver);
     }
 
     /**
@@ -1761,7 +1474,7 @@ public final class DataCatalogGrpc {
     public void deleteEntry(
         com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteEntryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteEntryMethod(), responseObserver);
     }
 
     /**
@@ -1774,7 +1487,7 @@ public final class DataCatalogGrpc {
     public void getEntry(
         com.google.cloud.datacatalog.v1beta1.GetEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetEntryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetEntryMethod(), responseObserver);
     }
 
     /**
@@ -1789,7 +1502,7 @@ public final class DataCatalogGrpc {
     public void lookupEntry(
         com.google.cloud.datacatalog.v1beta1.LookupEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
-      asyncUnimplementedUnaryCall(getLookupEntryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getLookupEntryMethod(), responseObserver);
     }
 
     /**
@@ -1803,7 +1516,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.ListEntriesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListEntriesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListEntriesMethod(), responseObserver);
     }
 
     /**
@@ -1820,7 +1533,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateTagTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateTagTemplateMethod(), responseObserver);
     }
 
     /**
@@ -1834,7 +1547,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetTagTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetTagTemplateMethod(), responseObserver);
     }
 
     /**
@@ -1853,7 +1566,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateTagTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateTagTemplateMethod(), responseObserver);
     }
 
     /**
@@ -1869,7 +1582,7 @@ public final class DataCatalogGrpc {
     public void deleteTagTemplate(
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteTagTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteTagTemplateMethod(), responseObserver);
     }
 
     /**
@@ -1887,7 +1600,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateTagTemplateFieldMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateTagTemplateFieldMethod(), responseObserver);
     }
 
     /**
@@ -1904,7 +1617,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateTagTemplateFieldMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateTagTemplateFieldMethod(), responseObserver);
     }
 
     /**
@@ -1921,7 +1634,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getRenameTagTemplateFieldMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRenameTagTemplateFieldMethod(), responseObserver);
     }
 
     /**
@@ -1937,7 +1650,7 @@ public final class DataCatalogGrpc {
     public void deleteTagTemplateField(
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteTagTemplateFieldMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteTagTemplateFieldMethod(), responseObserver);
     }
 
     /**
@@ -1956,7 +1669,7 @@ public final class DataCatalogGrpc {
     public void createTag(
         com.google.cloud.datacatalog.v1beta1.CreateTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Tag> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateTagMethod(), responseObserver);
     }
 
     /**
@@ -1969,7 +1682,7 @@ public final class DataCatalogGrpc {
     public void updateTag(
         com.google.cloud.datacatalog.v1beta1.UpdateTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Tag> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateTagMethod(), responseObserver);
     }
 
     /**
@@ -1982,7 +1695,7 @@ public final class DataCatalogGrpc {
     public void deleteTag(
         com.google.cloud.datacatalog.v1beta1.DeleteTagRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteTagMethod(), responseObserver);
     }
 
     /**
@@ -1996,7 +1709,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.ListTagsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListTagsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListTagsMethod(), responseObserver);
     }
 
     /**
@@ -2022,7 +1735,7 @@ public final class DataCatalogGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -2049,7 +1762,7 @@ public final class DataCatalogGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -2074,183 +1787,183 @@ public final class DataCatalogGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSearchCatalogMethodHelper(),
+              getSearchCatalogMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest,
                       com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>(
                       this, METHODID_SEARCH_CATALOG)))
           .addMethod(
-              getCreateEntryGroupMethodHelper(),
+              getCreateEntryGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest,
                       com.google.cloud.datacatalog.v1beta1.EntryGroup>(
                       this, METHODID_CREATE_ENTRY_GROUP)))
           .addMethod(
-              getUpdateEntryGroupMethodHelper(),
+              getUpdateEntryGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest,
                       com.google.cloud.datacatalog.v1beta1.EntryGroup>(
                       this, METHODID_UPDATE_ENTRY_GROUP)))
           .addMethod(
-              getGetEntryGroupMethodHelper(),
+              getGetEntryGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest,
                       com.google.cloud.datacatalog.v1beta1.EntryGroup>(
                       this, METHODID_GET_ENTRY_GROUP)))
           .addMethod(
-              getDeleteEntryGroupMethodHelper(),
+              getDeleteEntryGroupMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_ENTRY_GROUP)))
           .addMethod(
-              getListEntryGroupsMethodHelper(),
+              getListEntryGroupsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest,
                       com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>(
                       this, METHODID_LIST_ENTRY_GROUPS)))
           .addMethod(
-              getCreateEntryMethodHelper(),
+              getCreateEntryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateEntryRequest,
                       com.google.cloud.datacatalog.v1beta1.Entry>(this, METHODID_CREATE_ENTRY)))
           .addMethod(
-              getUpdateEntryMethodHelper(),
+              getUpdateEntryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest,
                       com.google.cloud.datacatalog.v1beta1.Entry>(this, METHODID_UPDATE_ENTRY)))
           .addMethod(
-              getDeleteEntryMethodHelper(),
+              getDeleteEntryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_ENTRY)))
           .addMethod(
-              getGetEntryMethodHelper(),
+              getGetEntryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.GetEntryRequest,
                       com.google.cloud.datacatalog.v1beta1.Entry>(this, METHODID_GET_ENTRY)))
           .addMethod(
-              getLookupEntryMethodHelper(),
+              getLookupEntryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.LookupEntryRequest,
                       com.google.cloud.datacatalog.v1beta1.Entry>(this, METHODID_LOOKUP_ENTRY)))
           .addMethod(
-              getListEntriesMethodHelper(),
+              getListEntriesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ListEntriesRequest,
                       com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>(
                       this, METHODID_LIST_ENTRIES)))
           .addMethod(
-              getCreateTagTemplateMethodHelper(),
+              getCreateTagTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplate>(
                       this, METHODID_CREATE_TAG_TEMPLATE)))
           .addMethod(
-              getGetTagTemplateMethodHelper(),
+              getGetTagTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplate>(
                       this, METHODID_GET_TAG_TEMPLATE)))
           .addMethod(
-              getUpdateTagTemplateMethodHelper(),
+              getUpdateTagTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplate>(
                       this, METHODID_UPDATE_TAG_TEMPLATE)))
           .addMethod(
-              getDeleteTagTemplateMethodHelper(),
+              getDeleteTagTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_TAG_TEMPLATE)))
           .addMethod(
-              getCreateTagTemplateFieldMethodHelper(),
+              getCreateTagTemplateFieldMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplateField>(
                       this, METHODID_CREATE_TAG_TEMPLATE_FIELD)))
           .addMethod(
-              getUpdateTagTemplateFieldMethodHelper(),
+              getUpdateTagTemplateFieldMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplateField>(
                       this, METHODID_UPDATE_TAG_TEMPLATE_FIELD)))
           .addMethod(
-              getRenameTagTemplateFieldMethodHelper(),
+              getRenameTagTemplateFieldMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest,
                       com.google.cloud.datacatalog.v1beta1.TagTemplateField>(
                       this, METHODID_RENAME_TAG_TEMPLATE_FIELD)))
           .addMethod(
-              getDeleteTagTemplateFieldMethodHelper(),
+              getDeleteTagTemplateFieldMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_TAG_TEMPLATE_FIELD)))
           .addMethod(
-              getCreateTagMethodHelper(),
+              getCreateTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateTagRequest,
                       com.google.cloud.datacatalog.v1beta1.Tag>(this, METHODID_CREATE_TAG)))
           .addMethod(
-              getUpdateTagMethodHelper(),
+              getUpdateTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateTagRequest,
                       com.google.cloud.datacatalog.v1beta1.Tag>(this, METHODID_UPDATE_TAG)))
           .addMethod(
-              getDeleteTagMethodHelper(),
+              getDeleteTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteTagRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_TAG)))
           .addMethod(
-              getListTagsMethodHelper(),
+              getListTagsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ListTagsRequest,
                       com.google.cloud.datacatalog.v1beta1.ListTagsResponse>(
                       this, METHODID_LIST_TAGS)))
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
@@ -2268,11 +1981,8 @@ public final class DataCatalogGrpc {
    * their data.
    * </pre>
    */
-  public static final class DataCatalogStub extends io.grpc.stub.AbstractStub<DataCatalogStub> {
-    private DataCatalogStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class DataCatalogStub
+      extends io.grpc.stub.AbstractAsyncStub<DataCatalogStub> {
     private DataCatalogStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2305,7 +2015,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSearchCatalogMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSearchCatalogMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2335,7 +2045,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateEntryGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateEntryGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2355,7 +2065,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateEntryGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateEntryGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2372,7 +2082,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.EntryGroup>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetEntryGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetEntryGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2391,7 +2101,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteEntryGroupMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteEntryGroupMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2408,7 +2118,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListEntryGroupsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListEntryGroupsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2429,7 +2139,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateEntryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateEntryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2448,7 +2158,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateEntryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateEntryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2469,7 +2179,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteEntryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteEntryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2485,9 +2195,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.GetEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetEntryMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetEntryMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2503,7 +2211,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.LookupEntryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Entry> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getLookupEntryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getLookupEntryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2520,7 +2228,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListEntriesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListEntriesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2540,7 +2248,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTagTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateTagTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2557,7 +2265,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetTagTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetTagTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2579,7 +2287,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTagTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateTagTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2598,7 +2306,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteTagTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteTagTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2619,7 +2327,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTagTemplateFieldMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateTagTemplateFieldMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2639,7 +2347,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTagTemplateFieldMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateTagTemplateFieldMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2659,7 +2367,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.TagTemplateField>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRenameTagTemplateFieldMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRenameTagTemplateFieldMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2678,7 +2386,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteTagTemplateFieldMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteTagTemplateFieldMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2700,9 +2408,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Tag> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTagMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCreateTagMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2716,9 +2422,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Tag> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTagMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateTagMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2732,9 +2436,7 @@ public final class DataCatalogGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteTagRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteTagMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteTagMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2749,9 +2451,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListTagsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListTagsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2778,7 +2478,7 @@ public final class DataCatalogGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2808,7 +2508,7 @@ public final class DataCatalogGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2836,7 +2536,7 @@ public final class DataCatalogGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2851,11 +2551,7 @@ public final class DataCatalogGrpc {
    * </pre>
    */
   public static final class DataCatalogBlockingStub
-      extends io.grpc.stub.AbstractStub<DataCatalogBlockingStub> {
-    private DataCatalogBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<DataCatalogBlockingStub> {
     private DataCatalogBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2886,8 +2582,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse searchCatalog(
         com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSearchCatalogMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSearchCatalogMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2913,7 +2608,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.EntryGroup createEntryGroup(
         com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateEntryGroupMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateEntryGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2929,7 +2624,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.EntryGroup updateEntryGroup(
         com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateEntryGroupMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateEntryGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2941,8 +2636,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.EntryGroup getEntryGroup(
         com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetEntryGroupMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetEntryGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2958,7 +2652,7 @@ public final class DataCatalogGrpc {
     public com.google.protobuf.Empty deleteEntryGroup(
         com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteEntryGroupMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteEntryGroupMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2970,8 +2664,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse listEntryGroups(
         com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEntryGroupsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListEntryGroupsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2988,8 +2681,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Entry createEntry(
         com.google.cloud.datacatalog.v1beta1.CreateEntryRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateEntryMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateEntryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3004,8 +2696,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Entry updateEntry(
         com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateEntryMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateEntryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3022,8 +2713,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.protobuf.Empty deleteEntry(
         com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteEntryMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteEntryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3035,7 +2725,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Entry getEntry(
         com.google.cloud.datacatalog.v1beta1.GetEntryRequest request) {
-      return blockingUnaryCall(getChannel(), getGetEntryMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetEntryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3049,8 +2739,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Entry lookupEntry(
         com.google.cloud.datacatalog.v1beta1.LookupEntryRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getLookupEntryMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getLookupEntryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3062,8 +2751,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.ListEntriesResponse listEntries(
         com.google.cloud.datacatalog.v1beta1.ListEntriesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEntriesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListEntriesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3079,7 +2767,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.TagTemplate createTagTemplate(
         com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateTagTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateTagTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3091,8 +2779,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.TagTemplate getTagTemplate(
         com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetTagTemplateMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetTagTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3110,7 +2797,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.TagTemplate updateTagTemplate(
         com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateTagTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateTagTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3126,7 +2813,7 @@ public final class DataCatalogGrpc {
     public com.google.protobuf.Empty deleteTagTemplate(
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteTagTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteTagTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3143,7 +2830,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.TagTemplateField createTagTemplateField(
         com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateTagTemplateFieldMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateTagTemplateFieldMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3159,7 +2846,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.TagTemplateField updateTagTemplateField(
         com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateTagTemplateFieldMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateTagTemplateFieldMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3175,7 +2862,7 @@ public final class DataCatalogGrpc {
     public com.google.cloud.datacatalog.v1beta1.TagTemplateField renameTagTemplateField(
         com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRenameTagTemplateFieldMethodHelper(), getCallOptions(), request);
+          getChannel(), getRenameTagTemplateFieldMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3191,7 +2878,7 @@ public final class DataCatalogGrpc {
     public com.google.protobuf.Empty deleteTagTemplateField(
         com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteTagTemplateFieldMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteTagTemplateFieldMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3209,7 +2896,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Tag createTag(
         com.google.cloud.datacatalog.v1beta1.CreateTagRequest request) {
-      return blockingUnaryCall(getChannel(), getCreateTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3221,7 +2908,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Tag updateTag(
         com.google.cloud.datacatalog.v1beta1.UpdateTagRequest request) {
-      return blockingUnaryCall(getChannel(), getUpdateTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3233,7 +2920,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.protobuf.Empty deleteTag(
         com.google.cloud.datacatalog.v1beta1.DeleteTagRequest request) {
-      return blockingUnaryCall(getChannel(), getDeleteTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3245,7 +2932,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.ListTagsResponse listTags(
         com.google.cloud.datacatalog.v1beta1.ListTagsRequest request) {
-      return blockingUnaryCall(getChannel(), getListTagsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListTagsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3269,8 +2956,7 @@ public final class DataCatalogGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3295,8 +2981,7 @@ public final class DataCatalogGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -3320,7 +3005,7 @@ public final class DataCatalogGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
   }
 
@@ -3333,11 +3018,7 @@ public final class DataCatalogGrpc {
    * </pre>
    */
   public static final class DataCatalogFutureStub
-      extends io.grpc.stub.AbstractStub<DataCatalogFutureStub> {
-    private DataCatalogFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<DataCatalogFutureStub> {
     private DataCatalogFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -3370,7 +3051,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.SearchCatalogResponse>
         searchCatalog(com.google.cloud.datacatalog.v1beta1.SearchCatalogRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSearchCatalogMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSearchCatalogMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3397,7 +3078,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
         createEntryGroup(com.google.cloud.datacatalog.v1beta1.CreateEntryGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateEntryGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateEntryGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3414,7 +3095,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
         updateEntryGroup(com.google.cloud.datacatalog.v1beta1.UpdateEntryGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateEntryGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateEntryGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3428,7 +3109,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.EntryGroup>
         getEntryGroup(com.google.cloud.datacatalog.v1beta1.GetEntryGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetEntryGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetEntryGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3444,7 +3125,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteEntryGroup(com.google.cloud.datacatalog.v1beta1.DeleteEntryGroupRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteEntryGroupMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteEntryGroupMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3458,7 +3139,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.ListEntryGroupsResponse>
         listEntryGroups(com.google.cloud.datacatalog.v1beta1.ListEntryGroupsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListEntryGroupsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListEntryGroupsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3477,7 +3158,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.Entry>
         createEntry(com.google.cloud.datacatalog.v1beta1.CreateEntryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateEntryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateEntryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3494,7 +3175,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.Entry>
         updateEntry(com.google.cloud.datacatalog.v1beta1.UpdateEntryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateEntryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateEntryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3512,7 +3193,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteEntry(com.google.cloud.datacatalog.v1beta1.DeleteEntryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteEntryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteEntryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3525,8 +3206,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.datacatalog.v1beta1.Entry>
         getEntry(com.google.cloud.datacatalog.v1beta1.GetEntryRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetEntryMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetEntryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3542,7 +3222,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.Entry>
         lookupEntry(com.google.cloud.datacatalog.v1beta1.LookupEntryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getLookupEntryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getLookupEntryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3556,7 +3236,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.ListEntriesResponse>
         listEntries(com.google.cloud.datacatalog.v1beta1.ListEntriesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListEntriesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListEntriesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3573,7 +3253,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
         createTagTemplate(com.google.cloud.datacatalog.v1beta1.CreateTagTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateTagTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateTagTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3587,7 +3267,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
         getTagTemplate(com.google.cloud.datacatalog.v1beta1.GetTagTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetTagTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetTagTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3606,7 +3286,7 @@ public final class DataCatalogGrpc {
             com.google.cloud.datacatalog.v1beta1.TagTemplate>
         updateTagTemplate(com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateTagTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateTagTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3622,7 +3302,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteTagTemplate(com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteTagTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteTagTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3641,7 +3321,7 @@ public final class DataCatalogGrpc {
         createTagTemplateField(
             com.google.cloud.datacatalog.v1beta1.CreateTagTemplateFieldRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateTagTemplateFieldMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateTagTemplateFieldMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3659,7 +3339,7 @@ public final class DataCatalogGrpc {
         updateTagTemplateField(
             com.google.cloud.datacatalog.v1beta1.UpdateTagTemplateFieldRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateTagTemplateFieldMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateTagTemplateFieldMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3677,7 +3357,7 @@ public final class DataCatalogGrpc {
         renameTagTemplateField(
             com.google.cloud.datacatalog.v1beta1.RenameTagTemplateFieldRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRenameTagTemplateFieldMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRenameTagTemplateFieldMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3694,7 +3374,7 @@ public final class DataCatalogGrpc {
         deleteTagTemplateField(
             com.google.cloud.datacatalog.v1beta1.DeleteTagTemplateFieldRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteTagTemplateFieldMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteTagTemplateFieldMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3713,8 +3393,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.datacatalog.v1beta1.Tag>
         createTag(com.google.cloud.datacatalog.v1beta1.CreateTagRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getCreateTagMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getCreateTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3727,8 +3406,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.datacatalog.v1beta1.Tag>
         updateTag(com.google.cloud.datacatalog.v1beta1.UpdateTagRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getUpdateTagMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getUpdateTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3740,8 +3418,7 @@ public final class DataCatalogGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteTag(
         com.google.cloud.datacatalog.v1beta1.DeleteTagRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getDeleteTagMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getDeleteTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3754,8 +3431,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.datacatalog.v1beta1.ListTagsResponse>
         listTags(com.google.cloud.datacatalog.v1beta1.ListTagsRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListTagsMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListTagsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3781,7 +3457,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3808,7 +3484,7 @@ public final class DataCatalogGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3833,7 +3509,7 @@ public final class DataCatalogGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
   }
 
@@ -4104,33 +3780,33 @@ public final class DataCatalogGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new DataCatalogFileDescriptorSupplier())
-                      .addMethod(getSearchCatalogMethodHelper())
-                      .addMethod(getCreateEntryGroupMethodHelper())
-                      .addMethod(getUpdateEntryGroupMethodHelper())
-                      .addMethod(getGetEntryGroupMethodHelper())
-                      .addMethod(getDeleteEntryGroupMethodHelper())
-                      .addMethod(getListEntryGroupsMethodHelper())
-                      .addMethod(getCreateEntryMethodHelper())
-                      .addMethod(getUpdateEntryMethodHelper())
-                      .addMethod(getDeleteEntryMethodHelper())
-                      .addMethod(getGetEntryMethodHelper())
-                      .addMethod(getLookupEntryMethodHelper())
-                      .addMethod(getListEntriesMethodHelper())
-                      .addMethod(getCreateTagTemplateMethodHelper())
-                      .addMethod(getGetTagTemplateMethodHelper())
-                      .addMethod(getUpdateTagTemplateMethodHelper())
-                      .addMethod(getDeleteTagTemplateMethodHelper())
-                      .addMethod(getCreateTagTemplateFieldMethodHelper())
-                      .addMethod(getUpdateTagTemplateFieldMethodHelper())
-                      .addMethod(getRenameTagTemplateFieldMethodHelper())
-                      .addMethod(getDeleteTagTemplateFieldMethodHelper())
-                      .addMethod(getCreateTagMethodHelper())
-                      .addMethod(getUpdateTagMethodHelper())
-                      .addMethod(getDeleteTagMethodHelper())
-                      .addMethod(getListTagsMethodHelper())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
+                      .addMethod(getSearchCatalogMethod())
+                      .addMethod(getCreateEntryGroupMethod())
+                      .addMethod(getUpdateEntryGroupMethod())
+                      .addMethod(getGetEntryGroupMethod())
+                      .addMethod(getDeleteEntryGroupMethod())
+                      .addMethod(getListEntryGroupsMethod())
+                      .addMethod(getCreateEntryMethod())
+                      .addMethod(getUpdateEntryMethod())
+                      .addMethod(getDeleteEntryMethod())
+                      .addMethod(getGetEntryMethod())
+                      .addMethod(getLookupEntryMethod())
+                      .addMethod(getListEntriesMethod())
+                      .addMethod(getCreateTagTemplateMethod())
+                      .addMethod(getGetTagTemplateMethod())
+                      .addMethod(getUpdateTagTemplateMethod())
+                      .addMethod(getDeleteTagTemplateMethod())
+                      .addMethod(getCreateTagTemplateFieldMethod())
+                      .addMethod(getUpdateTagTemplateFieldMethod())
+                      .addMethod(getRenameTagTemplateFieldMethod())
+                      .addMethod(getDeleteTagTemplateFieldMethod())
+                      .addMethod(getCreateTagMethod())
+                      .addMethod(getUpdateTagMethod())
+                      .addMethod(getDeleteTagMethod())
+                      .addMethod(getListTagsMethod())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/PolicyTagManagerGrpc.java
+++ b/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/PolicyTagManagerGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/datacatalog/v1beta1/policytagmanager.proto")
 public final class PolicyTagManagerGrpc {
 
@@ -40,30 +40,20 @@ public final class PolicyTagManagerGrpc {
   public static final String SERVICE_NAME = "google.cloud.datacatalog.v1beta1.PolicyTagManager";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateTaxonomyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      METHOD_CREATE_TAXONOMY = getCreateTaxonomyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getCreateTaxonomyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateTaxonomy",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Taxonomy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getCreateTaxonomyMethod() {
-    return getCreateTaxonomyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      getCreateTaxonomyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
@@ -78,10 +68,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.Taxonomy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "CreateTaxonomy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTaxonomy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -99,26 +86,18 @@ public final class PolicyTagManagerGrpc {
     return getCreateTaxonomyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteTaxonomyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_TAXONOMY = getDeleteTaxonomyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest, com.google.protobuf.Empty>
       getDeleteTaxonomyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteTaxonomy",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest, com.google.protobuf.Empty>
       getDeleteTaxonomyMethod() {
-    return getDeleteTaxonomyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest, com.google.protobuf.Empty>
-      getDeleteTaxonomyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest, com.google.protobuf.Empty>
         getDeleteTaxonomyMethod;
@@ -132,10 +111,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "DeleteTaxonomy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteTaxonomy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -153,30 +129,20 @@ public final class PolicyTagManagerGrpc {
     return getDeleteTaxonomyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateTaxonomyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      METHOD_UPDATE_TAXONOMY = getUpdateTaxonomyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getUpdateTaxonomyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateTaxonomy",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Taxonomy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getUpdateTaxonomyMethod() {
-    return getUpdateTaxonomyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      getUpdateTaxonomyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
@@ -191,10 +157,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.Taxonomy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "UpdateTaxonomy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTaxonomy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -212,30 +175,20 @@ public final class PolicyTagManagerGrpc {
     return getUpdateTaxonomyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListTaxonomiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
-      METHOD_LIST_TAXONOMIES = getListTaxonomiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
       getListTaxonomiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListTaxonomies",
+      requestType = com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
       getListTaxonomiesMethod() {
-    return getListTaxonomiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
-      getListTaxonomiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
             com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
@@ -250,10 +203,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "ListTaxonomies"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTaxonomies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -272,30 +222,20 @@ public final class PolicyTagManagerGrpc {
     return getListTaxonomiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetTaxonomyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      METHOD_GET_TAXONOMY = getGetTaxonomyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getGetTaxonomyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetTaxonomy",
+      requestType = com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.Taxonomy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
           com.google.cloud.datacatalog.v1beta1.Taxonomy>
       getGetTaxonomyMethod() {
-    return getGetTaxonomyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
-          com.google.cloud.datacatalog.v1beta1.Taxonomy>
-      getGetTaxonomyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
@@ -310,9 +250,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.Taxonomy>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager", "GetTaxonomy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTaxonomy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -330,30 +268,20 @@ public final class PolicyTagManagerGrpc {
     return getGetTaxonomyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreatePolicyTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      METHOD_CREATE_POLICY_TAG = getCreatePolicyTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getCreatePolicyTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreatePolicyTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.PolicyTag.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getCreatePolicyTagMethod() {
-    return getCreatePolicyTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      getCreatePolicyTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
@@ -368,10 +296,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.PolicyTag>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "CreatePolicyTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreatePolicyTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -389,26 +314,18 @@ public final class PolicyTagManagerGrpc {
     return getCreatePolicyTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeletePolicyTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_POLICY_TAG = getDeletePolicyTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest, com.google.protobuf.Empty>
       getDeletePolicyTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeletePolicyTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest, com.google.protobuf.Empty>
       getDeletePolicyTagMethod() {
-    return getDeletePolicyTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest, com.google.protobuf.Empty>
-      getDeletePolicyTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest, com.google.protobuf.Empty>
         getDeletePolicyTagMethod;
@@ -422,10 +339,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "DeletePolicyTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeletePolicyTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -443,30 +357,20 @@ public final class PolicyTagManagerGrpc {
     return getDeletePolicyTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdatePolicyTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      METHOD_UPDATE_POLICY_TAG = getUpdatePolicyTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getUpdatePolicyTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdatePolicyTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.PolicyTag.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getUpdatePolicyTagMethod() {
-    return getUpdatePolicyTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      getUpdatePolicyTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
@@ -481,10 +385,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.PolicyTag>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "UpdatePolicyTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdatePolicyTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -502,30 +403,20 @@ public final class PolicyTagManagerGrpc {
     return getUpdatePolicyTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListPolicyTagsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
-      METHOD_LIST_POLICY_TAGS = getListPolicyTagsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
           com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
       getListPolicyTagsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListPolicyTags",
+      requestType = com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
           com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
       getListPolicyTagsMethod() {
-    return getListPolicyTagsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
-          com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
-      getListPolicyTagsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
             com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
@@ -540,10 +431,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "ListPolicyTags"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListPolicyTags"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -562,30 +450,20 @@ public final class PolicyTagManagerGrpc {
     return getListPolicyTagsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetPolicyTagMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      METHOD_GET_POLICY_TAG = getGetPolicyTagMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getGetPolicyTagMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetPolicyTag",
+      requestType = com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.PolicyTag.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
           com.google.cloud.datacatalog.v1beta1.PolicyTag>
       getGetPolicyTagMethod() {
-    return getGetPolicyTagMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
-          com.google.cloud.datacatalog.v1beta1.PolicyTag>
-      getGetPolicyTagMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
@@ -600,9 +478,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.cloud.datacatalog.v1beta1.PolicyTag>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager", "GetPolicyTag"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetPolicyTag"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -620,26 +496,18 @@ public final class PolicyTagManagerGrpc {
     return getGetPolicyTagMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = PolicyTagManagerGrpc.getGetIamPolicyMethod) == null) {
@@ -650,9 +518,7 @@ public final class PolicyTagManagerGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager", "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -669,26 +535,18 @@ public final class PolicyTagManagerGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = PolicyTagManagerGrpc.getSetIamPolicyMethod) == null) {
@@ -699,9 +557,7 @@ public final class PolicyTagManagerGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager", "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -718,26 +574,18 @@ public final class PolicyTagManagerGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -753,10 +601,7 @@ public final class PolicyTagManagerGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManager",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -775,19 +620,43 @@ public final class PolicyTagManagerGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static PolicyTagManagerStub newStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerStub>() {
+          @java.lang.Override
+          public PolicyTagManagerStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static PolicyTagManagerBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerBlockingStub>() {
+          @java.lang.Override
+          public PolicyTagManagerBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerBlockingStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static PolicyTagManagerFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerFutureStub>() {
+          @java.lang.Override
+          public PolicyTagManagerFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerFutureStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -811,7 +680,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateTaxonomyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateTaxonomyMethod(), responseObserver);
     }
 
     /**
@@ -825,7 +694,7 @@ public final class PolicyTagManagerGrpc {
     public void deleteTaxonomy(
         com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteTaxonomyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteTaxonomyMethod(), responseObserver);
     }
 
     /**
@@ -839,7 +708,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateTaxonomyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateTaxonomyMethod(), responseObserver);
     }
 
     /**
@@ -854,7 +723,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListTaxonomiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListTaxonomiesMethod(), responseObserver);
     }
 
     /**
@@ -868,7 +737,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetTaxonomyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetTaxonomyMethod(), responseObserver);
     }
 
     /**
@@ -882,7 +751,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreatePolicyTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreatePolicyTagMethod(), responseObserver);
     }
 
     /**
@@ -895,7 +764,7 @@ public final class PolicyTagManagerGrpc {
     public void deletePolicyTag(
         com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeletePolicyTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeletePolicyTagMethod(), responseObserver);
     }
 
     /**
@@ -909,7 +778,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdatePolicyTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdatePolicyTagMethod(), responseObserver);
     }
 
     /**
@@ -923,7 +792,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListPolicyTagsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListPolicyTagsMethod(), responseObserver);
     }
 
     /**
@@ -937,7 +806,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetPolicyTagMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetPolicyTagMethod(), responseObserver);
     }
 
     /**
@@ -950,7 +819,7 @@ public final class PolicyTagManagerGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -963,7 +832,7 @@ public final class PolicyTagManagerGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -978,93 +847,93 @@ public final class PolicyTagManagerGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateTaxonomyMethodHelper(),
+              getCreateTaxonomyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest,
                       com.google.cloud.datacatalog.v1beta1.Taxonomy>(
                       this, METHODID_CREATE_TAXONOMY)))
           .addMethod(
-              getDeleteTaxonomyMethodHelper(),
+              getDeleteTaxonomyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_TAXONOMY)))
           .addMethod(
-              getUpdateTaxonomyMethodHelper(),
+              getUpdateTaxonomyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest,
                       com.google.cloud.datacatalog.v1beta1.Taxonomy>(
                       this, METHODID_UPDATE_TAXONOMY)))
           .addMethod(
-              getListTaxonomiesMethodHelper(),
+              getListTaxonomiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest,
                       com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>(
                       this, METHODID_LIST_TAXONOMIES)))
           .addMethod(
-              getGetTaxonomyMethodHelper(),
+              getGetTaxonomyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest,
                       com.google.cloud.datacatalog.v1beta1.Taxonomy>(this, METHODID_GET_TAXONOMY)))
           .addMethod(
-              getCreatePolicyTagMethodHelper(),
+              getCreatePolicyTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest,
                       com.google.cloud.datacatalog.v1beta1.PolicyTag>(
                       this, METHODID_CREATE_POLICY_TAG)))
           .addMethod(
-              getDeletePolicyTagMethodHelper(),
+              getDeletePolicyTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_POLICY_TAG)))
           .addMethod(
-              getUpdatePolicyTagMethodHelper(),
+              getUpdatePolicyTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest,
                       com.google.cloud.datacatalog.v1beta1.PolicyTag>(
                       this, METHODID_UPDATE_POLICY_TAG)))
           .addMethod(
-              getListPolicyTagsMethodHelper(),
+              getListPolicyTagsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest,
                       com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>(
                       this, METHODID_LIST_POLICY_TAGS)))
           .addMethod(
-              getGetPolicyTagMethodHelper(),
+              getGetPolicyTagMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest,
                       com.google.cloud.datacatalog.v1beta1.PolicyTag>(
                       this, METHODID_GET_POLICY_TAG)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
@@ -1083,11 +952,7 @@ public final class PolicyTagManagerGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerStub> {
-    private PolicyTagManagerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<PolicyTagManagerStub> {
     private PolicyTagManagerStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1109,7 +974,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTaxonomyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateTaxonomyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1126,7 +991,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteTaxonomyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteTaxonomyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1143,7 +1008,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTaxonomyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateTaxonomyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1161,7 +1026,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListTaxonomiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListTaxonomiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1178,7 +1043,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.Taxonomy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetTaxonomyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetTaxonomyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1195,7 +1060,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreatePolicyTagMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreatePolicyTagMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1211,7 +1076,7 @@ public final class PolicyTagManagerGrpc {
         com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeletePolicyTagMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeletePolicyTagMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1228,7 +1093,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdatePolicyTagMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdatePolicyTagMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1245,7 +1110,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListPolicyTagsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListPolicyTagsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1262,7 +1127,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.PolicyTag>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetPolicyTagMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetPolicyTagMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1278,7 +1143,7 @@ public final class PolicyTagManagerGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1294,7 +1159,7 @@ public final class PolicyTagManagerGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1312,7 +1177,7 @@ public final class PolicyTagManagerGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1327,11 +1192,7 @@ public final class PolicyTagManagerGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerBlockingStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerBlockingStub> {
-    private PolicyTagManagerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<PolicyTagManagerBlockingStub> {
     private PolicyTagManagerBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1351,8 +1212,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Taxonomy createTaxonomy(
         com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateTaxonomyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateTaxonomyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1365,8 +1225,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.protobuf.Empty deleteTaxonomy(
         com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteTaxonomyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteTaxonomyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1378,8 +1237,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Taxonomy updateTaxonomy(
         com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateTaxonomyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateTaxonomyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1392,8 +1250,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse listTaxonomies(
         com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListTaxonomiesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListTaxonomiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1405,8 +1262,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.Taxonomy getTaxonomy(
         com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetTaxonomyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetTaxonomyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1418,8 +1274,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.PolicyTag createPolicyTag(
         com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreatePolicyTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreatePolicyTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1431,8 +1286,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.protobuf.Empty deletePolicyTag(
         com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeletePolicyTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeletePolicyTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1444,8 +1298,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.PolicyTag updatePolicyTag(
         com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdatePolicyTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdatePolicyTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1457,8 +1310,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse listPolicyTags(
         com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListPolicyTagsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListPolicyTagsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1470,8 +1322,7 @@ public final class PolicyTagManagerGrpc {
      */
     public com.google.cloud.datacatalog.v1beta1.PolicyTag getPolicyTag(
         com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetPolicyTagMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetPolicyTagMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1482,8 +1333,7 @@ public final class PolicyTagManagerGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1494,8 +1344,7 @@ public final class PolicyTagManagerGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1509,7 +1358,7 @@ public final class PolicyTagManagerGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
   }
 
@@ -1522,11 +1371,7 @@ public final class PolicyTagManagerGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerFutureStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerFutureStub> {
-    private PolicyTagManagerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<PolicyTagManagerFutureStub> {
     private PolicyTagManagerFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1548,7 +1393,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
         createTaxonomy(com.google.cloud.datacatalog.v1beta1.CreateTaxonomyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateTaxonomyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateTaxonomyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1562,7 +1407,7 @@ public final class PolicyTagManagerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteTaxonomy(com.google.cloud.datacatalog.v1beta1.DeleteTaxonomyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteTaxonomyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteTaxonomyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1576,7 +1421,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
         updateTaxonomy(com.google.cloud.datacatalog.v1beta1.UpdateTaxonomyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateTaxonomyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateTaxonomyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1591,7 +1436,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.ListTaxonomiesResponse>
         listTaxonomies(com.google.cloud.datacatalog.v1beta1.ListTaxonomiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListTaxonomiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListTaxonomiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1605,7 +1450,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.Taxonomy>
         getTaxonomy(com.google.cloud.datacatalog.v1beta1.GetTaxonomyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetTaxonomyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetTaxonomyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1619,7 +1464,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
         createPolicyTag(com.google.cloud.datacatalog.v1beta1.CreatePolicyTagRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreatePolicyTagMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreatePolicyTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1632,7 +1477,7 @@ public final class PolicyTagManagerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deletePolicyTag(com.google.cloud.datacatalog.v1beta1.DeletePolicyTagRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeletePolicyTagMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeletePolicyTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1646,7 +1491,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
         updatePolicyTag(com.google.cloud.datacatalog.v1beta1.UpdatePolicyTagRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdatePolicyTagMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdatePolicyTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1660,7 +1505,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.ListPolicyTagsResponse>
         listPolicyTags(com.google.cloud.datacatalog.v1beta1.ListPolicyTagsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListPolicyTagsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListPolicyTagsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1674,7 +1519,7 @@ public final class PolicyTagManagerGrpc {
             com.google.cloud.datacatalog.v1beta1.PolicyTag>
         getPolicyTag(com.google.cloud.datacatalog.v1beta1.GetPolicyTagRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetPolicyTagMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetPolicyTagMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1687,7 +1532,7 @@ public final class PolicyTagManagerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1700,7 +1545,7 @@ public final class PolicyTagManagerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1715,7 +1560,7 @@ public final class PolicyTagManagerGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1890,19 +1735,19 @@ public final class PolicyTagManagerGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new PolicyTagManagerFileDescriptorSupplier())
-                      .addMethod(getCreateTaxonomyMethodHelper())
-                      .addMethod(getDeleteTaxonomyMethodHelper())
-                      .addMethod(getUpdateTaxonomyMethodHelper())
-                      .addMethod(getListTaxonomiesMethodHelper())
-                      .addMethod(getGetTaxonomyMethodHelper())
-                      .addMethod(getCreatePolicyTagMethodHelper())
-                      .addMethod(getDeletePolicyTagMethodHelper())
-                      .addMethod(getUpdatePolicyTagMethodHelper())
-                      .addMethod(getListPolicyTagsMethodHelper())
-                      .addMethod(getGetPolicyTagMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
+                      .addMethod(getCreateTaxonomyMethod())
+                      .addMethod(getDeleteTaxonomyMethod())
+                      .addMethod(getUpdateTaxonomyMethod())
+                      .addMethod(getListTaxonomiesMethod())
+                      .addMethod(getGetTaxonomyMethod())
+                      .addMethod(getCreatePolicyTagMethod())
+                      .addMethod(getDeletePolicyTagMethod())
+                      .addMethod(getUpdatePolicyTagMethod())
+                      .addMethod(getListPolicyTagsMethod())
+                      .addMethod(getGetPolicyTagMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/PolicyTagManagerSerializationGrpc.java
+++ b/grpc-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/PolicyTagManagerSerializationGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/datacatalog/v1beta1/policytagmanagerserialization.proto")
 public final class PolicyTagManagerSerializationGrpc {
 
@@ -41,30 +41,20 @@ public final class PolicyTagManagerSerializationGrpc {
       "google.cloud.datacatalog.v1beta1.PolicyTagManagerSerialization";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportTaxonomiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
-      METHOD_IMPORT_TAXONOMIES = getImportTaxonomiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
       getImportTaxonomiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportTaxonomies",
+      requestType = com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
       getImportTaxonomiesMethod() {
-    return getImportTaxonomiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
-      getImportTaxonomiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
             com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
@@ -82,10 +72,7 @@ public final class PolicyTagManagerSerializationGrpc {
                           com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManagerSerialization",
-                              "ImportTaxonomies"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportTaxonomies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -105,30 +92,20 @@ public final class PolicyTagManagerSerializationGrpc {
     return getImportTaxonomiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportTaxonomiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
-      METHOD_EXPORT_TAXONOMIES = getExportTaxonomiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
       getExportTaxonomiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportTaxonomies",
+      requestType = com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest.class,
+      responseType = com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
           com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
       getExportTaxonomiesMethod() {
-    return getExportTaxonomiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
-          com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
-      getExportTaxonomiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
             com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
@@ -146,10 +123,7 @@ public final class PolicyTagManagerSerializationGrpc {
                           com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.datacatalog.v1beta1.PolicyTagManagerSerialization",
-                              "ExportTaxonomies"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportTaxonomies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -171,19 +145,43 @@ public final class PolicyTagManagerSerializationGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static PolicyTagManagerSerializationStub newStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerSerializationStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationStub>() {
+          @java.lang.Override
+          public PolicyTagManagerSerializationStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerSerializationStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerSerializationStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static PolicyTagManagerSerializationBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerSerializationBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationBlockingStub>() {
+          @java.lang.Override
+          public PolicyTagManagerSerializationBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerSerializationBlockingStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerSerializationBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static PolicyTagManagerSerializationFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new PolicyTagManagerSerializationFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<PolicyTagManagerSerializationFutureStub>() {
+          @java.lang.Override
+          public PolicyTagManagerSerializationFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PolicyTagManagerSerializationFutureStub(channel, callOptions);
+          }
+        };
+    return PolicyTagManagerSerializationFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -211,7 +209,7 @@ public final class PolicyTagManagerSerializationGrpc {
         com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getImportTaxonomiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportTaxonomiesMethod(), responseObserver);
     }
 
     /**
@@ -227,21 +225,21 @@ public final class PolicyTagManagerSerializationGrpc {
         com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getExportTaxonomiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportTaxonomiesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getImportTaxonomiesMethodHelper(),
+              getImportTaxonomiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest,
                       com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>(
                       this, METHODID_IMPORT_TAXONOMIES)))
           .addMethod(
-              getExportTaxonomiesMethodHelper(),
+              getExportTaxonomiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest,
@@ -260,11 +258,7 @@ public final class PolicyTagManagerSerializationGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerSerializationStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerSerializationStub> {
-    private PolicyTagManagerSerializationStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<PolicyTagManagerSerializationStub> {
     private PolicyTagManagerSerializationStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -291,7 +285,7 @@ public final class PolicyTagManagerSerializationGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportTaxonomiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportTaxonomiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -310,7 +304,7 @@ public final class PolicyTagManagerSerializationGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportTaxonomiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportTaxonomiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -325,11 +319,7 @@ public final class PolicyTagManagerSerializationGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerSerializationBlockingStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerSerializationBlockingStub> {
-    private PolicyTagManagerSerializationBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<PolicyTagManagerSerializationBlockingStub> {
     private PolicyTagManagerSerializationBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -354,7 +344,7 @@ public final class PolicyTagManagerSerializationGrpc {
     public com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse importTaxonomies(
         com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getImportTaxonomiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getImportTaxonomiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -369,7 +359,7 @@ public final class PolicyTagManagerSerializationGrpc {
     public com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse exportTaxonomies(
         com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getExportTaxonomiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getExportTaxonomiesMethod(), getCallOptions(), request);
     }
   }
 
@@ -382,11 +372,7 @@ public final class PolicyTagManagerSerializationGrpc {
    * </pre>
    */
   public static final class PolicyTagManagerSerializationFutureStub
-      extends io.grpc.stub.AbstractStub<PolicyTagManagerSerializationFutureStub> {
-    private PolicyTagManagerSerializationFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<PolicyTagManagerSerializationFutureStub> {
     private PolicyTagManagerSerializationFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -412,7 +398,7 @@ public final class PolicyTagManagerSerializationGrpc {
             com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesResponse>
         importTaxonomies(com.google.cloud.datacatalog.v1beta1.ImportTaxonomiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportTaxonomiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportTaxonomiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -428,7 +414,7 @@ public final class PolicyTagManagerSerializationGrpc {
             com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesResponse>
         exportTaxonomies(com.google.cloud.datacatalog.v1beta1.ExportTaxonomiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportTaxonomiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportTaxonomiesMethod(), getCallOptions()), request);
     }
   }
 
@@ -532,8 +518,8 @@ public final class PolicyTagManagerSerializationGrpc {
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(
                           new PolicyTagManagerSerializationFileDescriptorSupplier())
-                      .addMethod(getImportTaxonomiesMethodHelper())
-                      .addMethod(getExportTaxonomiesMethodHelper())
+                      .addMethod(getImportTaxonomiesMethod())
+                      .addMethod(getExportTaxonomiesMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
-common_templates = gcp.CommonTemplates()
 
 versions = ['v1beta1']
 service = 'datacatalog'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern='v1beta1/artman_datacatalog_{version}.yaml',
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

