### PR TITLE
fix: whitelist gapic v2 autogenerated names to avoid breakages

### DIFF
--- a/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
+++ b/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
@@ -6,4 +6,14 @@
     <className>com/google/cloud/datacatalog/v1/*OrBuilder</className>
     <method>* get*(*)</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/datacatalog/v1/*OrBuilder</className>
+    <method>boolean contains*(*)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/datacatalog/v1/*OrBuilder</className>
+    <method>boolean has*(*)</method>
+  </difference>
 </differences>

--- a/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
+++ b/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
@@ -3,17 +3,7 @@
 <differences>
   <difference>
     <differenceType>7012</differenceType>
-    <className>com/google/cloud/datacatalog/v1/SearchCatalogRequest*OrBuilder</className>
-    <method>* getRestrictedLocation*(*)</method>
-  </difference>
-  <difference>
-    <differenceType>7012</differenceType>
-    <className>com/google/cloud/datacatalog/v1/SearchCatalogResponseOrBuilder</className>
-    <method>* getUnreachable*(*)</method>
-  </difference>
-  <difference>
-    <differenceType>7012</differenceType>
-    <className>com/google/cloud/datacatalog/v1/SearchCatalogResponseOrBuilder</className>
-    <method>* getUnreachableList()</method>
+    <className>com/google/cloud/datacatalog/v1/*OrBuilder</className>
+    <method>* get*(*)</method>
   </difference>
 </differences>

--- a/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
+++ b/proto-google-cloud-datacatalog-v1/clirr-ignored-differences.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/datacatalog/v1/SearchCatalogRequest*OrBuilder</className>
+    <method>* getRestrictedLocation*(*)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/datacatalog/v1/SearchCatalogResponseOrBuilder</className>
+    <method>* getUnreachable*(*)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/datacatalog/v1/SearchCatalogResponseOrBuilder</className>
+    <method>* getUnreachableList()</method>
+  </difference>
+</differences>


### PR DESCRIPTION
Pre-emptive change to prevent breakages by the Gapic v2 migration (code regeneration) for this repo. I have tested this locally with the regenerated code.